### PR TITLE
Add remote address to response

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,16 +40,16 @@ server.on('message', (msg, remote) => {
 				ttl: 30,
 				data: addr
 			})
-			server.send(dnsPacket.encode(response), remote.port)
+			server.send(dnsPacket.encode(response), remote.port, remote.address)
 		})
 		.catch (err => {
-			server.send(dnsPacket.encode(response), remote.port)
+			server.send(dnsPacket.encode(response), remote.port, remote.address)
 		})
 	} else if (upstream) {
 		const proxySocket = dgram.createSocket('udp4')
 
 		proxySocket.on('message', message => {
-		  server.send(message, remote.port)
+		  server.send(message, remote.port, remote.address)
 		})
 
 		proxySocket.send(msg, 0, msg.length, 53, upstream)


### PR DESCRIPTION
When no address is giving the fallback always is localhost.
But when you want to use this dns-to-mdns bridge from any other location like another docker container running in the same network but on a different machine, it just won't work.